### PR TITLE
Ícono de la listas de las ISO solo en la vista '/home' y en las rutas iso '/iso...'

### DIFF
--- a/src/_zeus/layout/components/header/Navbar.tsx
+++ b/src/_zeus/layout/components/header/Navbar.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../partials";
 import { useLayout } from "../../core";
 import { NavbarItemModules } from "./navbarItems/itemModules";
+import { useLocation } from "react-router-dom";
 
 const itemClass = "ms-1 ms-md-4";
 const btnClass =
@@ -16,6 +17,8 @@ const btnIconClass = "fs-2";
 
 export const Navbar = () => {
   const { config } = useLayout();
+  const location = useLocation();
+  
   return (
     <div className="app-navbar flex-shrink-0">
       <div className={clsx("app-navbar-item align-items-stretch", itemClass)}>
@@ -34,9 +37,12 @@ export const Navbar = () => {
         />
       </div>
 
-      <div className={clsx("app-navbar-item", itemClass)}>
-        <NavbarItemModules toggleBtnClass={clsx("btn-active-light-primary btn-custom")} />
-      </div>
+      {/*Mostramos el ícono de la lista de isos si estamos en "/home" y en las rutas que comiencen con "/iso..."*/}
+      {(location.pathname === "/home" || location.pathname.startsWith("/iso")) && (
+        <div className={clsx("app-navbar-item", itemClass)}>
+            <NavbarItemModules toggleBtnClass={clsx("btn-active-light-primary btn-custom")} />
+        </div>
+      )}
 
       <div className={clsx("app-navbar-item", itemClass)}>
         <div


### PR DESCRIPTION
-Se hizo que el icono de la lista de ISO solo se muestre si estamos en '/home' y en las rutas iso '/iso...'